### PR TITLE
Explicitly use UTC datetime in tests

### DIFF
--- a/tests/FlywheelEventStoreAdapterTest.php
+++ b/tests/FlywheelEventStoreAdapterTest.php
@@ -246,7 +246,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
         $streamEvent = UserCreated::withPayloadAndSpecifiedCreatedAt(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
             1,
-            new \DateTimeImmutable('30 seconds ago')
+            new \DateTimeImmutable('30 seconds ago', new \DateTimeZone('UTC'))
         );
 
         $streamEvent = $streamEvent->withAddedMetadata('tag', 'person');


### PR DESCRIPTION
Fix #9 (/cc @sandrokeil)
