### PR TITLE
Support for PHP 7.1

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,8 @@
+/**
+ * This file is part of the prooph/event-store-flywheel-adapter.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */

--- a/.php_cs
+++ b/.php_cs
@@ -1,26 +1,46 @@
 <?php
-
-$header = <<<EOF
-This file is part of the prooph/event-store-flywheel-adapter.
-
-(c) 2016 prooph software GmbH <contact@prooph.de>
-
-For the full copyright and license information, please view the LICENSE
-file that was distributed with this source code.
-EOF;
-
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
-
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(array(
-        'header_comment',
-        'ordered_use',
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('examples')
+    ->in('src')
+    ->in('tests');
+$config = Symfony\CS\Config\Config::create();
+$config->level(null);
+$config->fixers(
+    array(
+        'braces',
+        'class_definition',
+        'duplicate_semicolon',
+        'elseif',
+        'empty_return',
+        'encoding',
+        'eof_ending',
+        'function_call_space',
+        'function_declaration',
+        'indentation',
+        'join_function',
+        'line_after_namespace',
+        'linefeed',
+        'logical_not_operators_with_successor_space',
+        'lowercase_constants',
+        'lowercase_keywords',
+        'method_argument_space',
+        'multiple_use',
+        'no_trailing_whitespace_in_comment',
+        'object_operator',
+        'parenthesis',
+        'php_closing_tag',
+        'remove_lines_between_uses',
+        'single_line_after_imports',
         'short_array_syntax',
-    ))
-    ->setUsingCache(true)
-    ->setUsingLinter(false)
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()->in([__DIR__])
+        'short_tag',
+        'standardize_not_equal',
+        'switch_case_semicolon_to_colon',
+        'switch_case_space',
+        'trailing_spaces',
+        'unused_use',
+        'visibility',
+        'whitespacy_lines',
     )
-;
+);
+$config->finder($finder);
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,27 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.1
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 before_script:
   - composer self-update
-  - composer update
+  - composer update --prefer-source $DEPENDENCIES
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
+  - ./vendor/bin/docheader check config/ examples/ src/ tests/
 
 after_success:
-  - php vendor/bin/coveralls -v
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi
 
 notifications:
   webhooks:

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "container-interop/container-interop": "^1.1",
         "phpunit/phpunit": "^5.6",
         "phpunit/phpunit-mock-objects": "^3.3.1",
+        "sebastian/comparator": "^1.2",
         "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "sandrokeil/interop-config": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,19 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
-        "jamesmoss/flywheel": "^0.4.2",
-        "prooph/common": "^3.5",
-        "prooph/event-store": "^6.0"
+        "php": "^7.1",
+        "jamesmoss/flywheel": "^0.5.1",
+        "prooph/common": "dev-php_7_1 as 4.0.0",
+        "prooph/event-store": "dev-php_7_1 as 7.0.0"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "fabpot/php-cs-fixer": "^1.10",
-        "phpunit/phpunit": "^4.8 || ^5.2",
-        "sandrokeil/interop-config": "^1.0",
-        "satooshi/php-coveralls": "^1.0"
+        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit-mock-objects": "^3.3.1",
+        "friendsofphp/php-cs-fixer": "^1.12.2",
+        "sandrokeil/interop-config": "^1.0.0",
+        "satooshi/php-coveralls": "^1.0",
+        "malukenho/docheader": "^0.1.4"
     },
     "suggest": {
         "container-interop/container-interop": "For usage of provided factories",

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "phpunit/phpunit": "^5.6",
         "phpunit/phpunit-mock-objects": "^3.3.1",
         "sebastian/comparator": "^1.2",
+        "phpspec/prophecy": "^1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "sandrokeil/interop-config": "^1.0.0",
         "satooshi/php-coveralls": "^1.0",
@@ -59,5 +60,11 @@
     },
     "config": {
         "process-timeout": 0
-    }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/prolic/prophecy.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit-mock-objects": "^3.3.1",
         "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
-        "sandrokeil/interop-config": "^1.0.0",
+        "sandrokeil/interop-config": "^1.1.0",
         "satooshi/php-coveralls": "^1.0",
         "malukenho/docheader": "^0.1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "container-interop/container-interop": "^1.1",
         "phpunit/phpunit": "^5.6",
         "phpunit/phpunit-mock-objects": "^3.3.1",
+        "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "sandrokeil/interop-config": "^1.0.0",
         "satooshi/php-coveralls": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "phpunit/phpunit": "^5.6",
         "phpunit/phpunit-mock-objects": "^3.3.1",
         "sebastian/comparator": "^1.2",
-        "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "sandrokeil/interop-config": "^1.0.0",
         "satooshi/php-coveralls": "^1.0",
@@ -60,11 +59,5 @@
     },
     "config": {
         "process-timeout": 0
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/prolic/prophecy.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,5 +59,11 @@
     },
     "config": {
         "process-timeout": 0
-    }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/prolic/prophecy.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "sebastian/comparator": "^1.2",
         "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
-        "sandrokeil/interop-config": "^1.1.0",
+        "sandrokeil/interop-config": "^1.0.0",
         "satooshi/php-coveralls": "^1.0",
         "malukenho/docheader": "^0.1.4"
     },

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -1,13 +1,14 @@
 <?php
-
-/*
+/**
  * This file is part of the prooph/event-store-flywheel-adapter.
- *
- * (c) 2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2014-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 require __DIR__.'/../vendor/autoload.php';
 

--- a/src/Container/FlywheelEventStoreAdapterFactory.php
+++ b/src/Container/FlywheelEventStoreAdapterFactory.php
@@ -21,7 +21,7 @@ use Prooph\Common\Messaging\MessageConverter;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\EventStore\Adapter\Flywheel\FlywheelEventStoreAdapter;
-use Prooph\EventStore\Exception\ConfigurationException;
+use Prooph\EventStore\Adapter\Exception\ConfigurationException;
 
 final class FlywheelEventStoreAdapterFactory implements RequiresConfig, RequiresMandatoryOptions
 {
@@ -55,7 +55,7 @@ final class FlywheelEventStoreAdapterFactory implements RequiresConfig, Requires
         $config = $this->options($config)['adapter']['options'];
 
         if (!is_dir($config['dir'])) {
-            throw ConfigurationException::configurationError(sprintf(
+            throw new ConfigurationException(sprintf(
                 '%s was not able to locate %s',
                 __CLASS__,
                 $config['dir']

--- a/src/Container/FlywheelEventStoreAdapterFactory.php
+++ b/src/Container/FlywheelEventStoreAdapterFactory.php
@@ -54,7 +54,7 @@ final class FlywheelEventStoreAdapterFactory implements RequiresConfig, Requires
         $config = $container->get('config');
         $config = $this->options($config)['adapter']['options'];
 
-        if (!is_dir($config['dir'])) {
+        if (! is_dir($config['dir'])) {
             throw new ConfigurationException(sprintf(
                 '%s was not able to locate %s',
                 __CLASS__,

--- a/src/Container/FlywheelEventStoreAdapterFactory.php
+++ b/src/Container/FlywheelEventStoreAdapterFactory.php
@@ -1,13 +1,14 @@
 <?php
-
-/*
+/**
  * This file is part of the prooph/event-store-flywheel-adapter.
- *
- * (c) 2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2014-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Prooph\EventStore\Adapter\Flywheel\Container;
 
@@ -26,10 +27,7 @@ final class FlywheelEventStoreAdapterFactory implements RequiresConfig, Requires
 {
     use ConfigurationTrait;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dimensions()
+    public function dimensions(): array
     {
         return ['prooph', 'event_store'];
     }
@@ -39,17 +37,19 @@ final class FlywheelEventStoreAdapterFactory implements RequiresConfig, Requires
      */
     public function mandatoryOptions()
     {
-        return ['adapter' => ['options' => ['dir']]];
+        return [
+            'adapter' => [
+                'options' => [
+                    'dir'
+                ]
+            ]
+        ];
     }
 
     /**
-     * @param ContainerInterface $container
-     *
      * @throws ConfigurationException
-     *
-     * @return FlywheelEventStoreAdapter
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): FlywheelEventStoreAdapter
     {
         $config = $container->get('config');
         $config = $this->options($config)['adapter']['options'];

--- a/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
+++ b/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
@@ -89,25 +89,4 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
 
         $factory($container->reveal());
     }
-
-    /**
-     * @test
-     */
-    public function it_throws_exception_if_adapter_options_are_not_available(): void
-    {
-        $this->expectException(\Interop\Config\Exception\MandatoryOptionNotFoundException::class);
-
-        $container = $this->prophesize(ContainerInterface::class);
-
-        $config['prooph']['event_store']['adapter']['options'] = [];
-
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn($config);
-        $container->has(MessageFactory::class)->willReturn(false);
-        $container->has(MessageConverter::class)->willReturn(false);
-
-        $factory = new FlywheelEventStoreAdapterFactory();
-
-        $factory($container->reveal());
-    }
 }

--- a/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
+++ b/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
@@ -1,13 +1,14 @@
 <?php
-
-/*
+/**
  * This file is part of the prooph/event-store-flywheel-adapter.
- *
- * (c) 2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2014-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace ProophTest\EventStore\Adapter\Flywheel\Container;
 
@@ -15,6 +16,7 @@ use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\Adapter\Exception\ConfigurationException;
 use Prooph\EventStore\Adapter\Flywheel\Container\FlywheelEventStoreAdapterFactory;
 use Prooph\EventStore\Adapter\Flywheel\FlywheelEventStoreAdapter;
 
@@ -23,7 +25,7 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_create_adapter_using_configured_directory()
+    public function it_create_adapter_using_configured_directory(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -44,7 +46,7 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_injects_helpers_from_container_if_available()
+    public function it_injects_helpers_from_container_if_available(): void
     {
         $messageFactory = $this->prophesize(MessageFactory::class);
         $messageConverter = $this->prophesize(MessageConverter::class);
@@ -69,10 +71,11 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Prooph\EventStore\Exception\ConfigurationException
      */
-    public function it_throws_exception_if_adaptaer_directory_options_not_found()
+    public function it_throws_exception_if_adaptaer_directory_options_not_found(): void
     {
+        $this->expectException(ConfigurationException::class);
+
         $container = $this->prophesize(ContainerInterface::class);
 
         $config['prooph']['event_store']['adapter']['options']['dir'] = 'not-found-dir';
@@ -89,10 +92,11 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Interop\Config\Exception\MandatoryOptionNotFoundException
      */
-    public function it_throws_exception_if_adapter_options_are_not_available()
+    public function it_throws_exception_if_adapter_options_are_not_available(): void
     {
+        $this->expectException(\Interop\Config\Exception\MandatoryOptionNotFoundException::class);
+
         $container = $this->prophesize(ContainerInterface::class);
 
         $config['prooph']['event_store']['adapter']['options'] = [];

--- a/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
+++ b/tests/Container/FlywheelEventStorageAdapterFactoryTest.php
@@ -29,7 +29,7 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
     {
         $container = $this->prophesize(ContainerInterface::class);
 
-        $config['prooph']['event_store']['adapter']['options']['dir'] = __DIR__;
+        $config['prooph']['event_store']['default']['adapter']['options']['dir'] = __DIR__;
 
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn($config);
@@ -53,7 +53,7 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
 
-        $config['prooph']['event_store']['adapter']['options']['dir'] = __DIR__;
+        $config['prooph']['event_store']['default']['adapter']['options']['dir'] = __DIR__;
 
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn($config);
@@ -78,7 +78,7 @@ class FlywheelEventStorageAdapterFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
 
-        $config['prooph']['event_store']['adapter']['options']['dir'] = 'not-found-dir';
+        $config['prooph']['event_store']['default']['adapter']['options']['dir'] = 'not-found-dir';
 
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn($config);

--- a/tests/FlywheelEventStoreAdapterTest.php
+++ b/tests/FlywheelEventStoreAdapterTest.php
@@ -37,7 +37,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     {
         $this->rootDir = sys_get_temp_dir().'/FlywheelEventStoreAdapterTest_'.mt_rand();
 
-        if (!is_dir($this->rootDir) && !@mkdir($this->rootDir)) {
+        if (! is_dir($this->rootDir) && ! @mkdir($this->rootDir)) {
             throw new \RuntimeException('Unable to create the temporary root directory');
         }
 
@@ -50,7 +50,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (!$this->removePath($this->rootDir)) {
+        if (! $this->removePath($this->rootDir)) {
             throw new \RuntimeException('Unable to remove the temporary root directory');
         }
     }
@@ -59,7 +59,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     {
         if (is_file($path)) {
             return @unlink($path);
-        } elseif (!is_dir($path)) {
+        } elseif (! is_dir($path)) {
             return false;
         }
 

--- a/tests/FlywheelEventStoreAdapterTest.php
+++ b/tests/FlywheelEventStoreAdapterTest.php
@@ -1,13 +1,14 @@
 <?php
-
-/*
+/**
  * This file is part of the prooph/event-store-flywheel-adapter.
- *
- * (c) 2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2014-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace ProophTest\EventStore\Adapter\Flywheel;
 
@@ -32,7 +33,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
      */
     private $adapter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->rootDir = sys_get_temp_dir().'/FlywheelEventStoreAdapterTest_'.mt_rand();
 
@@ -47,14 +48,14 @@ class FlywheelEventStoreAdapterTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!$this->removePath($this->rootDir)) {
             throw new \RuntimeException('Unable to remove the temporary root directory');
         }
     }
 
-    private function removePath($path)
+    private function removePath(string $path): bool
     {
         if (is_file($path)) {
             return @unlink($path);
@@ -72,7 +73,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_and_load_a_stream()
+    public function it_creates_and_load_a_stream(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -99,7 +100,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_appends_events_to_a_stream()
+    public function it_appends_events_to_a_stream(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -128,7 +129,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_loads_events_from_min_version_on()
+    public function it_loads_events_from_min_version_on(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -153,7 +154,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_replays()
+    public function it_replays(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -180,7 +181,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_replays_from_specific_date()
+    public function it_replays_from_specific_date(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -207,7 +208,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_replays_events_of_two_aggregates_in_a_single_stream_in_correct_order()
+    public function it_replays_events_of_two_aggregates_in_a_single_stream_in_correct_order(): void
     {
         // Create stream
         $stream = $this->createStream();
@@ -238,10 +239,7 @@ class FlywheelEventStoreAdapterTest extends TestCase
         $this->assertEquals($expectedPayloads, $replayedPayloads);
     }
 
-    /**
-     * @return Stream
-     */
-    private function createStream()
+    private function createStream(): Stream
     {
         $streamEvent = UserCreated::withPayloadAndSpecifiedCreatedAt(
             ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],


### PR DESCRIPTION
- add support for PHP 7.1
- update flywheel dependency
- uses custom prooph/common branch ("prooph/common" : "dev-php_7_1 as 4.0")
- uses custom prooph/event-store branch ("prooph/common" : "dev-php_7_1 as 7.0")
